### PR TITLE
Publish GitHub Release on Tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   lint:
     docker:
-      - image: koalaman/shellcheck-alpine
+      - image: giantswarm/shellcheck-alpine:v0.6.0
     steps:
       - checkout
 
@@ -30,7 +30,7 @@ jobs:
 
   publish-github-release:
     docker:
-      - image: cibuilds/github:0.12
+      - image: giantswarm/github:0.12
     steps:
       - checkout
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,15 @@
 version: 2
 jobs:
+  lint:
+    docker:
+      - image: koalaman/shellcheck-alpine
+    steps:
+      - checkout
+
+      - run:
+          name: lint scripts
+          command: shellcheck -x ci-scripts/*
+
   build:
     working_directory: /home/circleci/.go_workspace/src/github.com/giantswarm/kubernetes-prometheus
     machine: true
@@ -18,8 +28,36 @@ jobs:
     - store_test_results:
         path: /tmp/results
 
+  publish-github-release:
+    docker:
+      - image: cibuilds/github:0.12
+    steps:
+      - checkout
+
+      - run:
+          name: "Package Helm Chart"
+          command: |
+            ./ci-scripts/package.sh ${CIRCLE_PROJECT_REPONAME} ${CIRCLE_TAG}
+
+      - run:
+          name: "Publish Release on GitHub"
+          command: |
+            ghr -t ${PERSONAL_ACCESS_TOKEN} -u giantswarm -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${CIRCLE_TAG} "${CIRCLE_PROJECT_REPONAME}-chart-${CIRCLE_TAG}.tgz"
+
 workflows:
   version: 2
   build-deploy:
     jobs:
-      - build
+      - lint
+      - build:
+          filters:
+            tags:
+              only: /^\d+\.\d+\.\d+$/
+      - publish-github-release:
+          requires:
+            - build
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^\d+\.\d+\.\d+$/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
       - run:
           name: "Publish Release on GitHub"
           command: |
-            ghr -t ${PERSONAL_ACCESS_TOKEN} -u giantswarm -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${CIRCLE_TAG} "${CIRCLE_PROJECT_REPONAME}-chart-${CIRCLE_TAG}.tgz"
+            ghr -t ${PERSONAL_ACCESS_TOKEN} -u giantswarm -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${CIRCLE_TAG} "${CIRCLE_PROJECT_REPONAME}-chart-${CIRCLE_TAG:1}.tgz"
 
 workflows:
   version: 2
@@ -52,7 +52,7 @@ workflows:
       - build:
           filters:
             tags:
-              only: /^\d+\.\d+\.\d+$/
+              only: /^v\d+\.\d+\.\d+$/
       - publish-github-release:
           requires:
             - build
@@ -60,4 +60,4 @@ workflows:
             branches:
               ignore: /.*/
             tags:
-              only: /^\d+\.\d+\.\d+$/
+              only: /^v\d+\.\d+\.\d+$/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   lint:
     docker:
-      - image: giantswarm/shellcheck-alpine:v0.6.0
+      - image: quay.io/giantswarm/shellcheck-alpine:v0.6.0
     steps:
       - checkout
 
@@ -30,7 +30,7 @@ jobs:
 
   publish-github-release:
     docker:
-      - image: giantswarm/github:0.12
+      - image: quay.io/giantswarm/github:0.12
     steps:
       - checkout
 

--- a/ci-scripts/package.sh
+++ b/ci-scripts/package.sh
@@ -5,7 +5,8 @@ set -o nounset
 set -o pipefail
 
 readonly PROJECT=$1
-readonly VERSION=$2
+readonly TAG=$2
+readonly VERSION=${TAG:1}
 
 readonly HELM_URL=https://storage.googleapis.com/kubernetes-helm
 readonly HELM_TARBALL=helm-v2.12.0-linux-amd64.tar.gz

--- a/ci-scripts/package.sh
+++ b/ci-scripts/package.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+readonly PROJECT=$1
+readonly VERSION=$2
+
+readonly HELM_URL=https://storage.googleapis.com/kubernetes-helm
+readonly HELM_TARBALL=helm-v2.12.0-linux-amd64.tar.gz
+
+main() {
+  if ! setup_helm_client; then
+    log_error "Helm client could not get installed."
+    exit 1
+  fi
+
+  if ! package_chart "${PROJECT}" "${VERSION}"; then
+    log_error "Helm Chart could not be packaged."
+    exit 1
+  fi
+
+  echo "Successfully packaged ${PROJECT}-chart-${VERSION}.tgz"
+}
+
+setup_helm_client() {
+    echo "Setting up Helm client..."
+
+    curl --user-agent curl-ci-sync -sSL -o "${HELM_TARBALL}" "${HELM_URL}/${HELM_TARBALL}"
+    tar xzf "${HELM_TARBALL}"
+
+    PATH="$(pwd)/linux-amd64/:$PATH"
+    helm init --client-only
+}
+
+package_chart() {
+  local project="${1?Specify project}"
+  local version="${2?Specify version}"
+
+  # Replace CI version with release version
+  sed -i 's/version:.*/version: '"${version}"'/' "helm/${project}-chart/Chart.yaml"
+
+  helm package --save=false "helm/${project}-chart"
+}
+
+log_error() {
+    printf '\e[31mERROR: %s\n\e[39m' "$1" >&2
+}
+
+main


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/4848

Adds CI for publishing a GH release using `ghr`(https://github.com/tcnksm/ghr) when pushing a tag. Also lints the shell script.