### PR TITLE
Switch API's for Kubernetes >= 1.16

### DIFF
--- a/helm/prometheus-chart/templates/alertmanager-deployment.yaml
+++ b/helm/prometheus-chart/templates/alertmanager-deployment.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.alertmanager.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/helm/prometheus-chart/templates/grafana-podsecuritypolicy.yaml
+++ b/helm/prometheus-chart/templates/grafana-podsecuritypolicy.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "prometheus.grafana.fullname" . }}

--- a/helm/prometheus-chart/templates/grafana-role.yaml
+++ b/helm/prometheus-chart/templates/grafana-role.yaml
@@ -9,7 +9,7 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 rules:
-- apiGroups:      ['extensions']
+- apiGroups:      ['policy']
   resources:      ['podsecuritypolicies']
   verbs:          ['use']
   resourceNames:  [{{ template "prometheus.grafana.fullname" . }}]

--- a/helm/prometheus-chart/templates/prometheus-deployment.yaml
+++ b/helm/prometheus-chart/templates/prometheus-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
 {{- if .Values.server.deploymentAnnotations }}

--- a/manifests-all.yaml
+++ b/manifests-all.yaml
@@ -5,7 +5,7 @@ kind: Namespace
 metadata:
   name: monitoring
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: prometheus
@@ -18,7 +18,7 @@ subjects:
   name: prometheus-k8s
   namespace: monitoring
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: prometheus
@@ -333,7 +333,7 @@ data:
       - channel: '#alertmanager-test'
         send_resolved: true
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: alertmanager
@@ -395,7 +395,7 @@ spec:
     port: 9093
     targetPort: 9093
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: grafana-core
@@ -405,6 +405,10 @@ metadata:
     component: core
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: grafana
+      component: core
   template:
     metadata:
       labels:
@@ -2552,7 +2556,7 @@ metadata:
   name: prometheus-core
   namespace: monitoring
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: prometheus-core
@@ -2562,6 +2566,10 @@ metadata:
     component: core
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: prometheus
+      component: core
   template:
     metadata:
       name: prometheus-main
@@ -2601,13 +2609,16 @@ spec:
         configMap:
           name: prometheus-rules
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: kube-state-metrics
   namespace: monitoring
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: kube-state-metrics
   template:
     metadata:
       labels:
@@ -2621,7 +2632,7 @@ spec:
         - containerPort: 8080
 ---
 # ---
-# apiVersion: rbac.authorization.k8s.io/v1beta1
+# apiVersion: rbac.authorization.k8s.io/v1
 # kind: ClusterRoleBinding
 # metadata:
 #   name: kube-state-metrics
@@ -2634,7 +2645,7 @@ spec:
 #   name: kube-state-metrics
 #   namespace: monitoring
 # ---
-# apiVersion: rbac.authorization.k8s.io/v1beta1
+# apiVersion: rbac.authorization.k8s.io/v1
 # kind: ClusterRole
 # metadata:
 #   name: kube-state-metrics
@@ -2648,7 +2659,7 @@ spec:
 #   - replicationcontrollers
 #   - limitranges
 #   verbs: ["list", "watch"]
-# - apiGroups: ["extensions"]
+# - apiGroups: ["extensions", "apps"]
 #   resources:
 #   - daemonsets
 #   - deployments
@@ -2677,9 +2688,8 @@ spec:
     protocol: TCP
   selector:
     app: kube-state-metrics
-
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: node-directory-size-metrics
@@ -2692,6 +2702,9 @@ metadata:
       These are scheduled on every node in the Kubernetes cluster.
       To choose directories from the node to check, just mount them on the `read-du` container below `/mnt`.
 spec:
+  selector:
+    matchLabels:
+      app: node-directory-size-metrics
   template:
     metadata:
       labels:
@@ -2751,7 +2764,7 @@ spec:
         emptyDir:
           medium: Memory
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: prometheus-node-exporter
@@ -2760,6 +2773,10 @@ metadata:
     app: prometheus
     component: node-exporter
 spec:
+  selector:
+    matchLabels:
+      app: prometheus
+      component: node-exporter
   template:
     metadata:
       name: prometheus-node-exporter

--- a/manifests/alertmanager/deployment.yaml
+++ b/manifests/alertmanager/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: alertmanager

--- a/manifests/grafana/deployment.yaml
+++ b/manifests/grafana/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: grafana-core
@@ -8,6 +8,10 @@ metadata:
     component: core
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: grafana
+      component: core
   template:
     metadata:
       labels:

--- a/manifests/prometheus/deployment.yaml
+++ b/manifests/prometheus/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: prometheus-core
@@ -8,6 +8,10 @@ metadata:
     component: core
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: prometheus
+      component: core
   template:
     metadata:
       name: prometheus-main

--- a/manifests/prometheus/kube-state-metrics/deployment.yaml
+++ b/manifests/prometheus/kube-state-metrics/deployment.yaml
@@ -1,10 +1,13 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: kube-state-metrics
   namespace: monitoring
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: kube-state-metrics
   template:
     metadata:
       labels:

--- a/manifests/prometheus/kube-state-metrics/rbac.yaml
+++ b/manifests/prometheus/kube-state-metrics/rbac.yaml
@@ -26,7 +26,7 @@
 #   - replicationcontrollers
 #   - limitranges
 #   verbs: ["list", "watch"]
-# - apiGroups: ["extensions"]
+# - apiGroups: ["apps"]
 #   resources:
 #   - daemonsets
 #   - deployments

--- a/manifests/prometheus/node-directory-size-metrics/daemonset.yaml
+++ b/manifests/prometheus/node-directory-size-metrics/daemonset.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: node-directory-size-metrics
@@ -11,6 +11,9 @@ metadata:
       These are scheduled on every node in the Kubernetes cluster.
       To choose directories from the node to check, just mount them on the `read-du` container below `/mnt`.
 spec:
+  selector:
+    matchLabels:
+      app: node-directory-size-metrics
   template:
     metadata:
       labels:

--- a/manifests/prometheus/node-exporter/daemonset.yaml
+++ b/manifests/prometheus/node-exporter/daemonset.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: prometheus-node-exporter
@@ -7,6 +7,10 @@ metadata:
     app: prometheus
     component: node-exporter
 spec:
+  selector:
+    matchLabels:
+      app: prometheus
+      component: node-exporter
   template:
     metadata:
       name: prometheus-node-exporter


### PR DESCRIPTION
Deprecation of API's were announced when using Kubernetes 1.16 and above. This leads to current failures when applying those manifests.

Recommendation to different API groups:

>NetworkPolicy (in the extensions/v1beta1 API group)
>* Migrate to use the networking.k8s.io/v1 API, available since v1.8. Existing persisted data can be >retrieved/updated via the networking.k8s.io/v1 API.
>
>PodSecurityPolicy (in the extensions/v1beta1 API group)
>
>* Migrate to use the policy/v1beta1 API, available since v1.10. Existing persisted data can be retrieved/updated via the policy/v1beta1 API.
>
>DaemonSet, Deployment, StatefulSet, and ReplicaSet (in the extensions/v1beta1 and apps/v1beta2 API groups)
>
>* Migrate to use the apps/v1 API, available since v1.9. Existing persisted data can be retrieved/updated via the apps/v1 API.