### PR TITLE
MemAvailable is more accurate for NodeMemoryUsage alert formula.

### DIFF
--- a/configs/prometheus/rules/mem-usage.rules
+++ b/configs/prometheus/rules/mem-usage.rules
@@ -10,7 +10,7 @@ ALERT NodeSwapUsage
   }
 
 ALERT NodeMemoryUsage
-  IF (((node_memory_MemTotal-node_memory_MemFree-node_memory_Cached)/(node_memory_MemTotal)*100)) > 75
+  IF (((node_memory_MemTotal-node_memory_MemAvailable)/(node_memory_MemTotal)*100)) > 75
   FOR 2m
   LABELS {
     severity="page"

--- a/manifests-all.yaml
+++ b/manifests-all.yaml
@@ -2856,7 +2856,7 @@ data:
       }
 
     ALERT NodeMemoryUsage
-      IF (((node_memory_MemTotal-node_memory_MemFree-node_memory_Cached)/(node_memory_MemTotal)*100)) > 75
+      IF (((node_memory_MemTotal-node_memory_MemAvailable)/(node_memory_MemTotal)*100)) > 75
       FOR 2m
       LABELS {
         severity="page"

--- a/manifests/prometheus/prometheus-rules.yaml
+++ b/manifests/prometheus/prometheus-rules.yaml
@@ -55,7 +55,7 @@ data:
       }
 
     ALERT NodeMemoryUsage
-      IF (((node_memory_MemTotal-node_memory_MemFree-node_memory_Cached)/(node_memory_MemTotal)*100)) > 75
+      IF (((node_memory_MemTotal-node_memory_MemAvailable)/(node_memory_MemTotal)*100)) > 75
       FOR 2m
       LABELS {
         severity="page"


### PR DESCRIPTION
Hi,

Regarding to NodeMemoryUsage, the fomula
`(((node_memory_MemTotal-node_memory_MemFree- node_memory_Cached)/(node_memory_MemTotal)*100)) > 75
`

should be as follows for more accuracy:
`(((node_memory_MemTotal-node_memory_MemAvailable)/(node_memory_MemTotal)*100)) > 75
`

since Linux kernel 3.14.

The reference is https://lkml.org/lkml/2013/11/7/264