### PR TITLE
adding namespace is not necessary.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -5,32 +5,24 @@ kubectl --namespace monitoring create configmap --dry-run prometheus-rules \
   --from-file=configs/prometheus/rules \
   --output yaml \
     > ./manifests/prometheus/prometheus-rules.yaml
-# Workaround since `--namespace monitoring` from above is not preserved
-echo "  namespace: monitoring" >> ./manifests/prometheus/prometheus-rules.yaml
 
 # Create ConfigMap for an external url
 kubectl --namespace monitoring create configmap --dry-run alertmanager-templates \
   --from-file=configs/alertmanager-templates \
   --output yaml \
     > ./manifests/alertmanager/alertmanager-templates.yaml
-# Workaround since `--namespace monitoring` from above is not preserved
-echo "  namespace: monitoring" >> ./manifests/alertmanager/alertmanager-templates.yaml
 
 # Create ConfigMap with Grafana dashboards and datasources
 kubectl --namespace monitoring create configmap --dry-run grafana-import-dashboards \
   --from-file=configs/grafana \
   --output yaml \
     > ./manifests/grafana/import-dashboards/configmap.yaml
-# Workaround since `--namespace monitoring` from above is not preserved
-echo "  namespace: monitoring" >> ./manifests/grafana/import-dashboards/configmap.yaml
 
 # Create ConfigMap with Prometheus config
 kubectl --namespace monitoring create configmap --dry-run prometheus-core \
   --from-file=configs/prometheus/prometheus.yaml \
   --output yaml \
     > ./manifests/prometheus/configmap.yaml
-# Workaround since `--namespace monitoring` from above is not preserved
-echo "  namespace: monitoring" >> ./manifests/prometheus/configmap.yaml
 
 # Create one single manifest file
 target="./manifests-all.yaml"


### PR DESCRIPTION
Adding `echo "  namespace: monitoring"`  in build.sh looks no more necessary.  It just duplicates the same line so that remove it.

I'm not sure which version of kubectl fixes, but at least the following works with my patch:

> $ kubectl version
> Client Version: version.Info{Major:"1", Minor:"15", GitVersion:"v1.15.3", GitCommit:"2d3c76f9091b6bec110a5e63777c332469e0cba2", GitTreeState:"clean", BuildDate:"2019-08-19T11:13:54Z", GoVersion:"go1.12.9", Compiler:"gc", Platform:"linux/amd64"}
> 
