### PR TITLE
Fix outdated Helm version

### DIFF
--- a/ci-scripts/package.sh
+++ b/ci-scripts/package.sh
@@ -8,8 +8,8 @@ readonly PROJECT=$1
 readonly TAG=$2
 readonly VERSION=${TAG:1}
 
-readonly HELM_URL=https://storage.googleapis.com/kubernetes-helm
-readonly HELM_TARBALL=helm-v2.12.0-linux-amd64.tar.gz
+readonly HELM_URL=https://get.helm.sh
+readonly HELM_TARBALL=helm-v2.17.0-linux-amd64.tar.gz
 
 main() {
   if ! setup_helm_client; then


### PR DESCRIPTION
Actually untested. But points now to the last official version of the Helm2 branch.